### PR TITLE
Bump httpclient in /jeecg-boot/jeecg-cloud-module/jeecg-cloud-sentinel

### DIFF
--- a/jeecg-boot/jeecg-cloud-module/jeecg-cloud-sentinel/pom.xml
+++ b/jeecg-boot/jeecg-cloud-module/jeecg-cloud-sentinel/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Bumps httpclient from 4.5.3 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>